### PR TITLE
Auto-use relaxed schema for Cucumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ to find out more.
 
 ```groovy
 plugins {
-    id "com.github.nagyesta.abort-mission-gradle-plugin" version "2.0.2"
+    id "com.github.nagyesta.abort-mission-gradle-plugin" version "2.1.0"
 }
 
 repositories {
@@ -54,7 +54,9 @@ abortMission {
     // - Setting the "abortMissionReport" task to the "finalize" the
     //   test task 
     skipTestAutoSetup false
-    //Define whether we want to use relaxed schema for JSON validation
+    //Define whether we want to use relaxed schema for JSON validation.
+    //Particularly useful when the Cucumber Booster is used or in case of
+    //a very special class name that does not match the basic regexp used.
     relaxedValidation false
     //Sets the directory where we want to look for the JSON input file
     //and save the HTML output

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     `java-gradle-plugin`
-    kotlin("jvm") version "1.5.0"
+    kotlin("jvm") version "1.6.0"
     `maven-publish`
-    id("com.gradle.plugin-publish") version "0.12.0"
+    id("com.gradle.plugin-publish") version "0.18.0"
     id("io.toolebox.git-versioner") version "1.6.5"
 }
 
@@ -36,8 +36,8 @@ versioner {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.5.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
     testImplementation(gradleTestKit())
 }
 

--- a/src/main/kotlin/com/github/nagyesta/abortmission/gradle/AbortMissionPlugin.kt
+++ b/src/main/kotlin/com/github/nagyesta/abortmission/gradle/AbortMissionPlugin.kt
@@ -89,7 +89,7 @@ class AbortMissionPlugin : Plugin<Project> {
         project: Project
     ): Boolean {
         val testImpl = project.configurations.findByName(TEST_IMPLEMENTATION_CONFIGURATION_NAME)
-        return testImpl.dependencies?.any { dependency ->
+        return testImpl?.dependencies?.any { dependency ->
             dependency.group.equals(CUCUMBER_BOOSTER_GROUP_ID)
                     && dependency.name.equals(CUCUMBER_BOOSTER_ARTIFACT_ID)
         } == true
@@ -122,7 +122,7 @@ class AbortMissionPlugin : Plugin<Project> {
             javaTask.outputs.file(htmlFile)
             javaTask.mainClass.set("org.springframework.boot.loader.JarLauncher")
             javaTask.workingDir = project.projectDir
-            javaTask.classpath = project.configurations.findByName(CONFIGURATION_NAME).asFileTree
+            javaTask.classpath = project.configurations.findByName(CONFIGURATION_NAME)!!.asFileTree
             javaTask.systemProperty("report.input", jsonFile.relativeTo(project.projectDir))
             javaTask.systemProperty("report.output", htmlFile.relativeTo(project.projectDir))
             javaTask.systemProperty("report.relaxed", relaxedValidation)
@@ -136,7 +136,7 @@ class AbortMissionPlugin : Plugin<Project> {
         project: Project
     ): AsyncJavaExecTask {
         val strongbackJars = project.configurations.findByName(STRONGBACK_CONFIGURATION_NAME)
-        val classPath = strongbackJars.asFileTree
+        val classPath = strongbackJars!!.asFileTree
         val javaTask = project.tasks.create(STRONGBACK_ERECT_JAVA_TASK_NAME, JavaExec::class.java) { javaTask ->
             javaTask.mainClass.set("com.github.nagyesta.abortmission.strongback.StrongbackErectorMain")
             addCommonStrongbackProperties(javaTask, abortMissionConfig, classPath, project.projectDir)
@@ -161,7 +161,7 @@ class AbortMissionPlugin : Plugin<Project> {
         erectTask: AsyncJavaExecTask,
         project: Project
     ): JavaExec {
-        val classPath = project.configurations.findByName(STRONGBACK_CONFIGURATION_NAME).asFileTree
+        val classPath = project.configurations.findByName(STRONGBACK_CONFIGURATION_NAME)!!.asFileTree
         return project.tasks.create(STRONGBACK_RETRACT_TASK_NAME, JavaExec::class.java) { javaTask ->
             javaTask.outputs.file(File(abortMissionConfig.reportDirectory, DEFAULT_JSON_FILE_NAME))
             javaTask.mainClass.set("com.github.nagyesta.abortmission.strongback.StrongbackRetractorMain")
@@ -194,7 +194,7 @@ class AbortMissionPlugin : Plugin<Project> {
         block: Test.() -> Unit
     ) {
         if (!skipTestPluginSetup) {
-            project.tasks.withType(Test::class.java).findByName("test").apply(block)
+            project.tasks.withType(Test::class.java).findByName("test")!!.apply(block)
         }
     }
 

--- a/src/main/kotlin/com/github/nagyesta/abortmission/gradle/AbortMissionPlugin.kt
+++ b/src/main/kotlin/com/github/nagyesta/abortmission/gradle/AbortMissionPlugin.kt
@@ -22,6 +22,9 @@ class AbortMissionPlugin : Plugin<Project> {
 
         const val CONFIGURATION_NAME = "abortMissionReporting"
         const val STRONGBACK_CONFIGURATION_NAME = "abortMissionStrongback"
+        const val TEST_IMPLEMENTATION_CONFIGURATION_NAME = "testImplementation"
+        const val CUCUMBER_BOOSTER_GROUP_ID = "com.github.nagyesta.abort-mission.boosters"
+        const val CUCUMBER_BOOSTER_ARTIFACT_ID = "abort.booster-cucumber-jvm"
 
         const val TASK_NAME = "abortMissionReport"
         const val STRONGBACK_ERECT_TASK_NAME = "abortMissionStrongbackErect"
@@ -36,17 +39,17 @@ class AbortMissionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.extensions.create(EXTENSION_NAME, AbortMissionConfig::class.java, project)
         project.configurations.create(CONFIGURATION_NAME)
-                .setVisible(true)
-                .description = "Abort-Mission report generator"
+            .setVisible(true)
+            .description = "Abort-Mission report generator"
         project.configurations.create(STRONGBACK_CONFIGURATION_NAME)
-                .setVisible(true)
-                .description = "Abort-Mission Strongback classpath"
+            .setVisible(true)
+            .description = "Abort-Mission Strongback classpath"
         project.afterEvaluate(this@AbortMissionPlugin::afterEvaluateHandler)
     }
 
     private fun afterEvaluateHandler(project: Project) {
         val abortMissionConfig = project.extensions
-                .findByType(AbortMissionConfig::class.java) ?: AbortMissionConfig(project)
+            .findByType(AbortMissionConfig::class.java) ?: AbortMissionConfig(project)
         project.dependencies.add(CONFIGURATION_NAME, "$GROUP_ID:$ARTIFACT_ID:${abortMissionConfig.toolVersion}")
 
         val abortMissionTask = defineAbortMissionReportTask(abortMissionConfig, project)
@@ -56,10 +59,10 @@ class AbortMissionPlugin : Plugin<Project> {
         if (abortMissionConfig.strongbackCoordinates.isNotBlank()) {
             val erectTask = defineAbortMissionStrongbackErectTask(abortMissionConfig, project)
             defineAbortMissionStrongbackRetractTask(
-                    abortMissionConfig,
-                    abortMissionTask,
-                    erectTask,
-                    project
+                abortMissionConfig,
+                abortMissionTask,
+                erectTask,
+                project
             )
         } else {
             setupTestTask(abortMissionConfig, abortMissionTask, project)
@@ -67,8 +70,8 @@ class AbortMissionPlugin : Plugin<Project> {
     }
 
     private fun addStrongbackDependencies(
-            abortMissionConfig: AbortMissionConfig,
-            project: Project
+        abortMissionConfig: AbortMissionConfig,
+        project: Project
     ) {
         val strongbackCoordinates = abortMissionConfig.strongbackCoordinates
         val toolVersion = abortMissionConfig.toolVersion
@@ -82,14 +85,24 @@ class AbortMissionPlugin : Plugin<Project> {
         }
     }
 
+    private fun hasCucumberDependency(
+        project: Project
+    ): Boolean {
+        val testImpl = project.configurations.findByName(TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+        return testImpl.dependencies?.any { dependency ->
+            dependency.group.equals(CUCUMBER_BOOSTER_GROUP_ID)
+                    && dependency.name.equals(CUCUMBER_BOOSTER_ARTIFACT_ID)
+        } == true
+    }
+
     private fun hasNoVersion(strongbackCoordinates: String) =
-            (strongbackCoordinates.split(':').size == 2
-                    && strongbackCoordinates.startsWith(STRONGBACK_GROUP_ID))
+        (strongbackCoordinates.split(':').size == 2
+                && strongbackCoordinates.startsWith(STRONGBACK_GROUP_ID))
 
     private fun setupTestTask(
-            abortMissionConfig: AbortMissionConfig,
-            abortMissionTask: JavaExec,
-            project: Project
+        abortMissionConfig: AbortMissionConfig,
+        abortMissionTask: JavaExec,
+        project: Project
     ) {
         forEachTestTasks(project, abortMissionConfig.skipTestAutoSetup) {
             this.systemProperty(REPORT_DIR_PROPERTY, abortMissionConfig.reportDirectory.absolutePath)
@@ -98,31 +111,32 @@ class AbortMissionPlugin : Plugin<Project> {
     }
 
     private fun defineAbortMissionReportTask(
-            abortMissionConfig: AbortMissionConfig,
-            project: Project
+        abortMissionConfig: AbortMissionConfig,
+        project: Project
     ): JavaExec {
         val htmlFile = File(abortMissionConfig.reportDirectory, DEFAULT_HTML_FILE_NAME)
         val jsonFile = File(abortMissionConfig.reportDirectory, DEFAULT_JSON_FILE_NAME)
+        val relaxedValidation = abortMissionConfig.relaxedValidation || hasCucumberDependency(project)
         return project.tasks.create(TASK_NAME, JavaExec::class.java) { javaTask ->
             javaTask.inputs.file(jsonFile)
             javaTask.outputs.file(htmlFile)
             javaTask.mainClass.set("org.springframework.boot.loader.JarLauncher")
             javaTask.workingDir = project.projectDir
-            javaTask.classpath = project.configurations.findByName(CONFIGURATION_NAME)!!.asFileTree
+            javaTask.classpath = project.configurations.findByName(CONFIGURATION_NAME).asFileTree
             javaTask.systemProperty("report.input", jsonFile.relativeTo(project.projectDir))
             javaTask.systemProperty("report.output", htmlFile.relativeTo(project.projectDir))
-            javaTask.systemProperty("report.relaxed", abortMissionConfig.relaxedValidation)
+            javaTask.systemProperty("report.relaxed", relaxedValidation)
             javaTask.systemProperty("report.failOnError", abortMissionConfig.failOnError)
             redirectLogs(javaTask)
         }
     }
 
     private fun defineAbortMissionStrongbackErectTask(
-            abortMissionConfig: AbortMissionConfig,
-            project: Project
+        abortMissionConfig: AbortMissionConfig,
+        project: Project
     ): AsyncJavaExecTask {
         val strongbackJars = project.configurations.findByName(STRONGBACK_CONFIGURATION_NAME)
-        val classPath = strongbackJars!!.asFileTree
+        val classPath = strongbackJars.asFileTree
         val javaTask = project.tasks.create(STRONGBACK_ERECT_JAVA_TASK_NAME, JavaExec::class.java) { javaTask ->
             javaTask.mainClass.set("com.github.nagyesta.abortmission.strongback.StrongbackErectorMain")
             addCommonStrongbackProperties(javaTask, abortMissionConfig, classPath, project.projectDir)
@@ -142,20 +156,22 @@ class AbortMissionPlugin : Plugin<Project> {
     }
 
     private fun defineAbortMissionStrongbackRetractTask(
-            abortMissionConfig: AbortMissionConfig,
-            reportTask: JavaExec,
-            erectTask: AsyncJavaExecTask,
-            project: Project
+        abortMissionConfig: AbortMissionConfig,
+        reportTask: JavaExec,
+        erectTask: AsyncJavaExecTask,
+        project: Project
     ): JavaExec {
-        val classPath = project.configurations.findByName(STRONGBACK_CONFIGURATION_NAME)!!.asFileTree
+        val classPath = project.configurations.findByName(STRONGBACK_CONFIGURATION_NAME).asFileTree
         return project.tasks.create(STRONGBACK_RETRACT_TASK_NAME, JavaExec::class.java) { javaTask ->
             javaTask.outputs.file(File(abortMissionConfig.reportDirectory, DEFAULT_JSON_FILE_NAME))
             javaTask.mainClass.set("com.github.nagyesta.abortmission.strongback.StrongbackRetractorMain")
             addCommonStrongbackProperties(javaTask, abortMissionConfig, classPath, project.projectDir)
             disableUpToDateChecks(javaTask)
             redirectLogs(javaTask)
-            javaTask.systemProperty(REPORT_DIR_PROPERTY,
-                    abortMissionConfig.reportDirectory.relativeTo(project.projectDir))
+            javaTask.systemProperty(
+                REPORT_DIR_PROPERTY,
+                abortMissionConfig.reportDirectory.relativeTo(project.projectDir)
+            )
             forEachTestTasks(project, abortMissionConfig.skipTestAutoSetup) {
                 this.finalizedBy(javaTask)
             }
@@ -172,11 +188,13 @@ class AbortMissionPlugin : Plugin<Project> {
         }
     }
 
-    private fun forEachTestTasks(project: Project,
-                                 skipTestPluginSetup: Boolean,
-                                 block: Test.() -> Unit) {
+    private fun forEachTestTasks(
+        project: Project,
+        skipTestPluginSetup: Boolean,
+        block: Test.() -> Unit
+    ) {
         if (!skipTestPluginSetup) {
-            project.tasks.withType(Test::class.java).findByName("test")!!.apply(block)
+            project.tasks.withType(Test::class.java).findByName("test").apply(block)
         }
     }
 
@@ -186,10 +204,10 @@ class AbortMissionPlugin : Plugin<Project> {
     }
 
     private fun addCommonStrongbackProperties(
-            javaTask: JavaExec,
-            abortMissionConfig: AbortMissionConfig,
-            classPath: FileTree,
-            workDir: File
+        javaTask: JavaExec,
+        abortMissionConfig: AbortMissionConfig,
+        classPath: FileTree,
+        workDir: File
     ) {
         javaTask.classpath = classPath
         javaTask.workingDir = workDir
@@ -197,8 +215,10 @@ class AbortMissionPlugin : Plugin<Project> {
             javaTask.systemProperty("abort-mission.telemetry.server.useExternal", true)
         }
         if (abortMissionConfig.strongbackPassword.isNotBlank()) {
-            javaTask.systemProperty("abort-mission.telemetry.server.password",
-                    abortMissionConfig.strongbackPassword)
+            javaTask.systemProperty(
+                "abort-mission.telemetry.server.password",
+                abortMissionConfig.strongbackPassword
+            )
         }
         if (abortMissionConfig.strongbackPort > 0) {
             javaTask.systemProperty("abort-mission.telemetry.server.port", abortMissionConfig.strongbackPort)


### PR DESCRIPTION
- When Cucumber-JVM Booster is a dependency of testImplementation, relaxed schema becomes default

{minor}