### PR TITLE
Upgrade to JDK 17

### DIFF
--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -44,11 +44,11 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: 'Build with Gradle'
         uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,11 +35,11 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Build with Gradle
         uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
         with:

--- a/.github/workflows/update-dependency-checksums.yml
+++ b/.github/workflows/update-dependency-checksums.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PUBLISH_KEY }}
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: "Remove previous version"
         run: cp gradle/verification-metadata-clean.xml gradle/verification-metadata.xml
       - name: "Update checksums"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Abort-Mission](.github/assets/Abort-Mission-logo_export_transparent_640.png)
 
 [![GitHub license](https://img.shields.io/github/license/nagyesta/abort-mission-gradle-plugin?color=informational)](https://raw.githubusercontent.com/nagyesta/abort-mission-gradle-plugin/main/LICENSE)
-[![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
+[![Java version](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)](https://img.shields.io/badge/Java%20version-17-yellow?logo=java)
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/abort-mission-gradle-plugin?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/abort-mission-gradle-plugin/releases)
 [![Gradle Plugin](https://img.shields.io/badge/gradle-plugin-blue?logo=gradle)](https://plugins.gradle.org/plugin/com.github.nagyesta.abort-mission-gradle-plugin)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/abort-mission-gradle-plugin/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/abort-mission-gradle-plugin/actions/workflows/gradle.yml)
@@ -28,7 +28,7 @@ to find out more.
 
 ```groovy
 plugins {
-    id "com.github.nagyesta.abort-mission-gradle-plugin" version "4.0.0"
+    id "com.github.nagyesta.abort-mission-gradle-plugin" version "5.0.0"
 }
 
 repositories {
@@ -60,7 +60,7 @@ abortMission {
     relaxedValidation false
     //Sets the directory where we want to look for the JSON input file
     //and save the HTML output
-    reportDirectory file("${buildDir}/reports/abort-mission/")
+    reportDirectory layout.buildDirectory.dir("reports/abort-mission/").get().getAsFile()
     //Controls whether the report generator should fail if any failed
     //test cases where in the report
     failOnError false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ versioner {
 }
 
 tasks {
-    withType<KotlinCompile> { kotlinOptions { jvmTarget = "11" } }
+    withType<KotlinCompile> { kotlinOptions { jvmTarget = "17" } }
 }
 
 dependencies {

--- a/gradle-tests/minimal-groovy-off/build.gradle
+++ b/gradle-tests/minimal-groovy-off/build.gradle
@@ -9,7 +9,7 @@ version = "0.0.1"
 dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation "com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:4.0.0"
+    testImplementation "com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:5.0.0"
 }
 
 tasks.named('test') {
@@ -18,7 +18,7 @@ tasks.named('test') {
 
 abortMission {
     skipTestAutoSetup = true
-    toolVersion = "4.0.0"
+    toolVersion = "5.0.0"
 }
 
 repositories {

--- a/gradle-tests/minimal-groovy/build.gradle
+++ b/gradle-tests/minimal-groovy/build.gradle
@@ -9,7 +9,7 @@ version = "0.0.1"
 dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation "com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:4.0.0"
+    testImplementation "com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:5.0.0"
 }
 
 tasks.named('test') {

--- a/gradle-tests/minimal-kts-off/build.gradle.kts
+++ b/gradle-tests/minimal-kts-off/build.gradle.kts
@@ -8,7 +8,7 @@ version = "0.0.1"
 
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:4.0.0")
+    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:5.0.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -18,7 +18,7 @@ tasks.withType<Test> {
 
 abortMission {
     skipTestAutoSetup = true
-    toolVersion = "4.0.0"
+    toolVersion = "5.0.0"
 }
 
 repositories {

--- a/gradle-tests/minimal-kts/build.gradle.kts
+++ b/gradle-tests/minimal-kts/build.gradle.kts
@@ -9,7 +9,7 @@ version = "0.0.1"
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:4.0.0")
+    testImplementation("com.github.nagyesta.abort-mission.boosters:abort.booster-junit-jupiter:5.0.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/com/github/nagyesta/abortmission/gradle/AbortMissionConfig.kt
+++ b/src/main/kotlin/com/github/nagyesta/abortmission/gradle/AbortMissionConfig.kt
@@ -14,14 +14,14 @@ open class AbortMissionConfig(project: Project) {
         const val DEFAULT_VERSION = "+"
         const val DEFAULT_RELAXED_VALIDATION = false
         const val DEFAULT_SKIP_TEST_AUTO_SETUP = false
-        const val DEFAULT_REPORT_DIRECTORY = "/reports/abort-mission/"
+        const val DEFAULT_REPORT_DIRECTORY = "reports/abort-mission/"
         const val DEFAULT_FAIL_ON_ERROR = false
     }
 
     init {
         skipTestAutoSetup = DEFAULT_SKIP_TEST_AUTO_SETUP
         relaxedValidation = DEFAULT_RELAXED_VALIDATION
-        reportDirectory = File(project.buildDir, DEFAULT_REPORT_DIRECTORY)
+        reportDirectory = project.layout.buildDirectory.dir(DEFAULT_REPORT_DIRECTORY).get().asFile
         toolVersion = DEFAULT_VERSION
         failOnError = DEFAULT_FAIL_ON_ERROR
     }


### PR DESCRIPTION
__Issue:__ https://github.com/nagyesta/abort-mission/issues/377

### Description
<!-- A short summary of changes -->

- Upgrades JDK versions to 17 in all workflows
- Prepares Abort Mission version updates (to use the JDK 17 Abort Mission version)
- Stops using the deprecated buildDir Gradle reference

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

- This is a breaking change as the JDK version is updated from 11 to 17
<!-- Any additional remarks you may have. -->
